### PR TITLE
I manage the background behind the first two members

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { MouseTrail } from "./components/MouseTrail";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { teamMembers } from "./data/team";
 import { Analytics } from "@vercel/analytics/react";
+
 function App() {
 	return (
 		<div className="relative min-h-screen">
@@ -20,10 +21,11 @@ function App() {
 				</p>
 				<ThemeToggle />
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-					{teamMembers.map((member) => (
+					{teamMembers.map((member, index) => (
 						<TeamMember
 							key={member.name}
 							{...member}
+							isFirstTwo={index < 2}
 						/>
 					))}
 				</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { TeamMember } from "./components/TeamMember";
 // import { HackathonCarousel } from "./components/HackathonCarousel";
 import { Background } from "./components/Background";
 import { MouseTrail } from "./components/MouseTrail";
+import { ThemeToggle } from "./components/ThemeToggle";
 import { teamMembers } from "./data/team";
 import { Analytics } from "@vercel/analytics/react";
 function App() {
@@ -17,6 +18,7 @@ function App() {
 				<p className="text-4xl md:text-4xl text-center font-bold bg-gradient-to-r from-primary via-primary/80 to-primary bg-clip-text text-transparent mb-3 animate-gradient  h-20">
 					Members of the Community
 				</p>
+				<ThemeToggle />
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 					{teamMembers.map((member) => (
 						<TeamMember

--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -1,7 +1,7 @@
 export function Background() {
   return (
     <div className="fixed inset-0 -z-10">
-      {/*Drack*/}
+      {/*Dark*/}
       <div className="absolute inset-0 dark:bg-[radial-gradient(circle_at_50%_50%,_#4F46E5_0%,_transparent_25%)] opacity-20 animate-pulse-slow dark:animate-pulse-slow" />
       <div className="absolute inset-0 dark:bg-[radial-gradient(circle_at_80%_20%,_#7C3AED_0%,_transparent_25%)] opacity-20 animate-pulse-slower dark:animate-pulse-slower" />
       <div className="absolute inset-0">

--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -1,13 +1,24 @@
 export function Background() {
   return (
     <div className="fixed inset-0 -z-10">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,_#4F46E5_0%,_transparent_25%)] opacity-20 animate-pulse-slow" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_20%,_#7C3AED_0%,_transparent_25%)] opacity-20 animate-pulse-slower" />
+      {/*Drack*/}
+      <div className="absolute inset-0 dark:bg-[radial-gradient(circle_at_50%_50%,_#4F46E5_0%,_transparent_25%)] opacity-20 animate-pulse-slow dark:animate-pulse-slow" />
+      <div className="absolute inset-0 dark:bg-[radial-gradient(circle_at_80%_20%,_#7C3AED_0%,_transparent_25%)] opacity-20 animate-pulse-slower dark:animate-pulse-slower" />
       <div className="absolute inset-0">
-        <div className="absolute h-[200px] w-[200px] rounded-full bg-indigo-500/30 blur-[100px] animate-blob" />
-        <div className="absolute h-[200px] w-[200px] rounded-full bg-purple-500/30 blur-[100px] animate-blob animation-delay-2000" />
-        <div className="absolute h-[200px] w-[200px] rounded-full bg-blue-500/30 blur-[100px] animate-blob animation-delay-4000" />
+        <div className="absolute h-[200px] w-[200px] rounded-full bg-indigo-500/30 blur-[100px] animate-blob dark:animate-blob" />
+        <div className="absolute h-[200px] w-[200px] rounded-full bg-purple-500/30 blur-[100px] animate-blob animation-delay-2000 dark:animation-delay-2000" />
+        <div className="absolute h-[200px] w-[200px] rounded-full bg-blue-500/30 blur-[100px] animate-blob animation-delay-4000 dark:animation-delay-4000" />
       </div>
+
+      {/*Light*/}
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,_#22D3EE_0%,_transparent_25%)] opacity-30 animate-pulse-slow dark:hidden" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_20%,_#818CF8_0%,_transparent_50%)] opacity-30 animate-pulse-slower dark:hidden" />
+      <div className="absolute inset-0">
+        <div className="absolute h-[200px] w-[200px] rounded-full bg-sky-400/40 blur-[100px] animate-blob dark:hidden" />
+        <div className="absolute h-[200px] w-[200px] rounded-full bg-violet-400/40 blur-[100px] animate-blob animation-delay-2000 dark:hidden" />
+        <div className="absolute h-[200px] w-[200px] rounded-full bg-indigo-400/40 blur-[100px] animate-blob animation-delay-4000 dark:hidden" />
+      </div>
+
       <div className="absolute inset-0 bg-grid-white/[0.02] bg-[size:50px_50px]" />
     </div>
   );

--- a/src/components/TeamMember.tsx
+++ b/src/components/TeamMember.tsx
@@ -4,70 +4,97 @@ import { Github, Linkedin, Twitter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface TeamMemberProps {
-  name: string;
-  role: string;
-  bio: string;
-  image: string;
-  expertise: string[];
-  social: {
-    github?: string;
-    linkedin?: string;
-    twitter?: string;
-  };
+    name: string;
+    role: string;
+    bio: string;
+    image: string;
+    expertise: string[];
+    social: {
+      github?: string;
+      linkedin?: string;
+      twitter?: string;
+    };
+    isFirstTwo?: boolean;
 }
 
-export function TeamMember({ name, role, bio, image, expertise, social }: TeamMemberProps) {
-  return (
-    <Card className="overflow-hidden bg-gradient-to-br from-black/60 via-black/40 to-transparent border-none hover:from-primary/20 hover:via-primary/10 hover:to-transparent transition-all duration-300 group">
-      <CardContent className="p-6">
-        <div className="flex flex-col items-center">
-          <div className="relative mb-4">
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-transparent rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-            <img
-              src={image}
-              alt={name}
-              className="w-32 h-32 rounded-full object-cover border-2 border-primary/20 group-hover:border-primary/40 transition-all duration-300 transform group-hover:scale-105"
-            />
+export function TeamMember({ 
+  name, 
+  role, 
+  bio, 
+  image, 
+  expertise, 
+  social, 
+  isFirstTwo 
+}: TeamMemberProps) {
+    return (
+      <Card className={`
+        overflow-hidden 
+        border-none 
+        transition-all 
+        duration-300 
+        group
+        ${isFirstTwo 
+          ? `
+            bg-gradient-to-br from-indigo-900/30 via-purple-900/20 to-black/10 
+            dark:from-indigo-950/50 dark:via-purple-950/30 dark:to-black/20
+            hover:from-indigo-900/50 hover:via-purple-900/40 hover:to-black/20
+            dark:hover:from-indigo-900/70 dark:hover:via-purple-900/60 dark:hover:to-black/30
+          `
+          : `
+            bg-gradient-to-br from-black/60 via-black/40 to-transparent 
+            hover:from-primary/20 hover:via-primary/10 hover:to-transparent
+          `
+        }
+      `}>
+        <CardContent className="p-6">
+          <div className="flex flex-col items-center">
+            <div className="relative mb-4">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-transparent rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+              <img
+                src={image}
+                alt={name}
+                className="w-32 h-32 rounded-full object-cover border-2 border-primary/20 group-hover:border-primary/40 transition-all duration-300 transform group-hover:scale-105"
+              />
+            </div>
+            <h3 className="text-xl font-bold text-primary mb-1 group-hover:text-primary/80 transition-colors">{name}</h3>
+            <p className="text-muted-foreground mb-2">{role}</p>
+            <div className="flex flex-wrap justify-center gap-2 mb-4">
+              {expertise.map((skill) => (
+                <Badge
+                  key={skill}
+                  variant="secondary"
+                  className="bg-primary/10 hover:bg-primary/20 transition-colors"
+                >
+                  {skill}
+                </Badge>
+              ))}
+            </div>
+            <p className="text-sm text-muted-foreground text-center mb-4 group-hover:text-muted-foreground/80 transition-colors">{bio}</p>
+            <div className="flex gap-2">
+              {social.github && (
+                <Button variant="ghost" size="icon" className="hover:bg-primary/20 transition-colors" asChild>
+                  <a href={social.github} target="_blank" rel="noopener noreferrer">
+                    <Github className="w-4 h-4" />
+                  </a>
+                </Button>
+              )}
+              {social.linkedin && (
+                <Button variant="ghost" size="icon" className="hover:bg-primary/20 transition-colors" asChild>
+                  <a href={social.linkedin} target="_blank" rel="noopener noreferrer">
+                    <Linkedin className="w-4 h-4" />
+                  </a>
+                </Button>
+              )}
+              {social.twitter && (
+                <Button variant="ghost" size="icon" className="hover:bg-primary/20 transition-colors" asChild>
+                  <a href={social.twitter} target="_blank" rel="noopener noreferrer">
+                    <Twitter className="w-4 h-4" />
+                  </a>
+                </Button>
+              )}
+            </div>
           </div>
-          <h3 className="text-xl font-bold text-primary mb-1 group-hover:text-primary/80 transition-colors">{name}</h3>
-          <p className="text-muted-foreground mb-2">{role}</p>
-          <div className="flex flex-wrap justify-center gap-2 mb-4">
-            {expertise.map((skill) => (
-              <Badge 
-                key={skill} 
-                variant="secondary" 
-                className="bg-primary/10 hover:bg-primary/20 transition-colors"
-              >
-                {skill}
-              </Badge>
-            ))}
-          </div>
-          <p className="text-sm text-muted-foreground text-center mb-4 group-hover:text-muted-foreground/80 transition-colors">{bio}</p>
-          <div className="flex gap-2">
-            {social.github && (
-              <Button variant="ghost" size="icon" className="hover:bg-primary/20 transition-colors" asChild>
-                <a href={social.github} target="_blank" rel="noopener noreferrer">
-                  <Github className="w-4 h-4" />
-                </a>
-              </Button>
-            )}
-            {social.linkedin && (
-              <Button variant="ghost" size="icon" className="hover:bg-primary/20 transition-colors" asChild>
-                <a href={social.linkedin} target="_blank" rel="noopener noreferrer">
-                  <Linkedin className="w-4 h-4" />
-                </a>
-              </Button>
-            )}
-            {social.twitter && (
-              <Button variant="ghost" size="icon" className="hover:bg-primary/20 transition-colors" asChild>
-                <a href={social.twitter} target="_blank" rel="noopener noreferrer">
-                  <Twitter className="w-4 h-4" />
-                </a>
-              </Button>
-            )}
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
+        </CardContent>
+      </Card>
+    );
 }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+export function ThemeToggle() {
+    const [theme, setTheme] = useState(() => 
+    localStorage.getItem("theme") || "light"
+);
+
+useEffect(() => {
+    if (theme === "dark") {
+        document.documentElement.classList.add("dark");
+    } else {
+        document.documentElement.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+}, [theme]);
+
+return (
+    <button
+        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        className="absolute top-4 right-4 p-2 rounded-xl transition-all duration-200 hover:bg-gray-300 dark:hover:bg-gray-600"
+    >
+    {theme === "dark" ? <Sun className="w-6 h-6 text-yellow-500" /> : <Moon className="w-6 h-6 text-gray-800" />}
+    </button>
+    );
+}
+
+export default ThemeToggle;

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,28 @@
 
 @layer base {
 	:root {
+		--background: 240 10% 96%;
+		--foreground: 240 10% 3.9%;
+		--card: 240 10% 96%;
+		--card-foreground: 240 10% 3.9%;
+		--popover: 240 10% 96%;
+		--popover-foreground: 240 10% 3.9%;
+		--primary: 246 84% 59%;
+		--primary-foreground: 240 10% 3.9%;
+		--secondary: 271 91% 58%;
+		--secondary-foreground: 240 10% 3.9%;
+		--muted: 240 5% 80%;
+		--muted-foreground: 240 5% 30%;
+		--accent: 217 91% 60%;
+		--accent-foreground: 240 10% 3.9%;
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 240 10% 3.9%;
+		--border: 240 5% 80%;
+		--input: 240 5% 80%;
+		--ring: 246 84% 59%;
+	}
+
+	.dark {
 		--background: 240 10% 3.9%;
 		--foreground: 0 0% 98%;
 		--card: 240 10% 3.9%;


### PR DESCRIPTION
![1](https://github.com/user-attachments/assets/9a68a621-d6ae-4790-ae58-1efe96b575a5)
![2](https://github.com/user-attachments/assets/94746eb3-450c-4c5a-9e87-2cbfe6d85aa7)

In this update, I modified the TeamMember component to highlight the first two members with a custom color gradient. I added an isFirstTwo prop that allows a different background to be applied to the first two members, with hover effects that change the intensity of the gradient. The implementation maintains the original card structure, adding only a layer of visual customization for the first team members.